### PR TITLE
BPS-65/S3 버킷 설정 및 Configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ out/
 .vscode/
 
 .env
+
+/**/resources/application.properties

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-batch'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/github/bluekey/s3/config/S3Configuration.java
+++ b/src/main/java/com/github/bluekey/s3/config/S3Configuration.java
@@ -1,0 +1,32 @@
+package com.github.bluekey.s3.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Configuration {
+	@Value("${cloud.aws.credentials.access-key}")
+	private String accessKey;
+	@Value("${cloud.aws.credentials.secret-key}")
+	private String secretKey;
+	@Value("${cloud.aws.region.static}")
+	private String region;
+
+	private AWSStaticCredentialsProvider createAwsCredentialsProvider() {
+		BasicAWSCredentials basicAWSCredentials = new BasicAWSCredentials(this.accessKey, this.secretKey);
+		return new AWSStaticCredentialsProvider(basicAWSCredentials);
+	}
+
+	@Bean
+	public AmazonS3Client amazonS3Client() {
+		return (AmazonS3Client) AmazonS3Client.builder()
+				.withRegion(region)
+				.withCredentials(createAwsCredentialsProvider())
+				.build();
+	}
+
+}

--- a/src/main/java/com/github/bluekey/s3/manager/AwsS3Manager.java
+++ b/src/main/java/com/github/bluekey/s3/manager/AwsS3Manager.java
@@ -1,0 +1,72 @@
+package com.github.bluekey.s3.manager;
+
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AwsS3Manager implements ResourceManager {
+	@Value("${cloud.aws.s3.bucket}")
+	private String bucket;
+	private final AmazonS3Client amazonS3Client;
+
+	/**
+	 * s3에 파일을 업로드 합니다.
+	 *
+	 * @param multipartFile 업로드할 파일
+	 * @param key 		 s3에 저장될 파일의 이름 혹은 경로 포함 이름
+	 */
+	public void upload(MultipartFile multipartFile, String key) {
+		log.info("uploading file to s3: {}", key);
+		ObjectMetadata objectMetadata = createObjectMetadata(multipartFile);
+		try {
+			PutObjectRequest putObjectRequest = new PutObjectRequest(bucket, key, multipartFile.getInputStream(), objectMetadata);
+			amazonS3Client.putObject(putObjectRequest);
+		}
+		catch (AmazonS3Exception | IOException e) {
+			// TODO: amazonS3에 대한 exception 처리라서 따로 에러 메세지 처리를 안해줬으나, 다른 exception과 포맷을 통일
+			log.error("s3 upload error: {}", e.getMessage());
+			e.getStackTrace();
+		}
+	}
+
+	/**
+	 * s3에 업로드할 파일의 메타데이터를 생성합니다.
+	 *
+	 * @param multipartFile 업로드할 파일
+	 * @return 업로드할 파일의 메타데이터
+	 */
+	// TODO: File size는 application.properties에서 관리
+	private ObjectMetadata createObjectMetadata(MultipartFile multipartFile) {
+		ObjectMetadata objectMetadata = new ObjectMetadata();
+		objectMetadata.setContentType(multipartFile.getContentType());
+		objectMetadata.setContentLength(multipartFile.getSize());
+		return objectMetadata;
+	}
+
+	/**
+	 * s3에 저장된 파일을 삭제합니다.
+	 *
+	 * @param key 삭제할 파일의 이름 혹은 경로 포함 이름
+	 */
+	public void delete(String key) {
+		log.info("deleting file from s3: {}", key);
+		try {
+			amazonS3Client.deleteObject(bucket, key);
+		} catch (AmazonS3Exception e) {
+			log.error("s3 delete error: {}", e.getMessage());
+			e.getStackTrace();
+		}
+	}
+
+}

--- a/src/main/java/com/github/bluekey/s3/manager/ResourceManager.java
+++ b/src/main/java/com/github/bluekey/s3/manager/ResourceManager.java
@@ -1,0 +1,8 @@
+package com.github.bluekey.s3.manager;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ResourceManager {
+	void upload(MultipartFile multipartFile, String key);
+	void delete(String key);
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## What is this PR do?

- backend에서 사용할 S3 버킷 설정
- S3 Configuration 설정
- ResourceManager 인터페이스 생성
- S3Manager로 ResourceManager 구현
- 파일 업로드, 삭제 확인

버킷 설정을 application 딴에서만 파일을 업로드하고 삭제할 수 있도록 해서 s3 버킷에 들어가서 파일을 확인할 수는 없는 상태입니다. 혹시 s3 콘솔에서 객체가 제대로 올라갔는지 확인하고 싶으시면 정책을 따로 변경하시거나, 저한테 말씀해주시면 개발기간에는 객체를 따로 확인할 수 있도록 바꿔놓겠습니다.
우선 저는 개인적으로 `application.properites`로 credentials한 값들을 관리하고 있고, 깃허브에 올라가면 안되는 파일이니 따로 공유드리겠습니다.
 
## How it Works
- [ ] : Task1
- [ ] : Task2

## Tests
- [ ] : Test1
- [ ] : Test2

## Reference
- reference1
