### PR TITLE
BPS-218/드롭다운 UI용 아티스트 리스트 조회 API

### DIFF
--- a/src/main/java/com/github/bluekey/controller/member/ArtistController.java
+++ b/src/main/java/com/github/bluekey/controller/member/ArtistController.java
@@ -171,7 +171,7 @@ public class ArtistController {
     })
     @GetMapping("/simple")
     public ResponseEntity<SimpleArtistAccountListResponseDto> getSimpleArtists() {
-        return ok().build();
+        return ok(memberService.getSimpleArtistAccounts());
     }
 
 }

--- a/src/main/java/com/github/bluekey/dto/artist/SimpleArtistAccountDto.java
+++ b/src/main/java/com/github/bluekey/dto/artist/SimpleArtistAccountDto.java
@@ -1,5 +1,6 @@
 package com.github.bluekey.dto.artist;
 
+import com.github.bluekey.entity.member.Member;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -18,9 +19,9 @@ public class SimpleArtistAccountDto {
     private String enName;
 
     @Builder
-    public SimpleArtistAccountDto(final Long memberId, final String name, final String enName) {
-        this.memberId = memberId;
-        this.name = name;
-        this.enName = enName;
+    public SimpleArtistAccountDto(Member member) {
+        this.memberId = member.getId();
+        this.name = member.getName();
+        this.enName = member.getEnName();
     }
 }

--- a/src/main/java/com/github/bluekey/dto/response/artist/SimpleArtistAccountListResponseDto.java
+++ b/src/main/java/com/github/bluekey/dto/response/artist/SimpleArtistAccountListResponseDto.java
@@ -1,6 +1,7 @@
 package com.github.bluekey.dto.response.artist;
 
 import com.github.bluekey.dto.artist.SimpleArtistAccountDto;
+import com.github.bluekey.entity.member.Member;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -8,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -18,7 +20,13 @@ public class SimpleArtistAccountListResponseDto {
     private List<SimpleArtistAccountDto> artists;
 
     @Builder
-    public SimpleArtistAccountListResponseDto(List<SimpleArtistAccountDto> artists) {
+    private SimpleArtistAccountListResponseDto(List<SimpleArtistAccountDto> artists) {
         this.artists = artists;
+    }
+
+    public static SimpleArtistAccountListResponseDto from(List<Member> artists) {
+        return SimpleArtistAccountListResponseDto.builder()
+                .artists(artists.stream().map(SimpleArtistAccountDto::new).collect(Collectors.toList()))
+                .build();
     }
 }

--- a/src/main/java/com/github/bluekey/repository/member/MemberRepository.java
+++ b/src/main/java/com/github/bluekey/repository/member/MemberRepository.java
@@ -1,7 +1,7 @@
 package com.github.bluekey.repository.member;
 import com.github.bluekey.entity.member.Member;
 import com.github.bluekey.entity.member.MemberRole;
-import java.awt.print.Pageable;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -24,4 +24,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
 	Page<Member> findMembersByType(MemberType type, PageRequest pageable);
 	Page<Member> findMembersByRole(MemberRole role, PageRequest pageable);
+
+	List<Member> findMemberByRoleAndIsRemovedFalse(MemberRole role);
 }

--- a/src/main/java/com/github/bluekey/service/member/MemberService.java
+++ b/src/main/java/com/github/bluekey/service/member/MemberService.java
@@ -4,12 +4,12 @@ import com.github.bluekey.dto.admin.AdminAccountDto;
 import com.github.bluekey.dto.admin.AdminProfileUpdateDto;
 import com.github.bluekey.dto.artist.ArtistAccountDto;
 import com.github.bluekey.dto.request.admin.AdminArtistProfileRequestDto;
-import com.github.bluekey.dto.request.admin.AdminProfileUpdateRequestDto;
 import com.github.bluekey.dto.request.artist.ArtistProfileRequestDto;
 import com.github.bluekey.dto.response.admin.AdminAccountsResponseDto;
 import com.github.bluekey.dto.response.admin.AdminProfileResponseDto;
 import com.github.bluekey.dto.response.artist.ArtistAccountsResponseDto;
 import com.github.bluekey.dto.response.artist.ArtistProfileResponseDto;
+import com.github.bluekey.dto.response.artist.SimpleArtistAccountListResponseDto;
 import com.github.bluekey.entity.member.Member;
 import com.github.bluekey.entity.member.MemberRole;
 import com.github.bluekey.entity.member.MemberType;
@@ -18,6 +18,8 @@ import com.github.bluekey.exception.ErrorCode;
 import com.github.bluekey.exception.member.MemberNotFoundException;
 import com.github.bluekey.repository.member.MemberRepository;
 import com.github.bluekey.util.ImageUploadUtil;
+
+import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -82,6 +84,12 @@ public class MemberService {
 				.totalItems(artistList.getTotalElements())
 				.contents(artistList.getContent().stream()
 						.map(ArtistAccountDto::from).collect(Collectors.toList())).build();
+	}
+
+	@Transactional(readOnly = true)
+	public SimpleArtistAccountListResponseDto getSimpleArtistAccounts() {
+		List<Member> artists = memberRepository.findMemberByRoleAndIsRemovedFalse(MemberRole.ARTIST);
+		return SimpleArtistAccountListResponseDto.from(artists);
 	}
 
 	public void validateAdminEmail(String email) {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## What is this PR do?

수록곡 추가시에 사용되는 DropDown UI에서 사용되는 Simple 버전의 Artist 리스트 조회 API 개발

## Tests
- [x] : PostMan 환경에서 테스트
```json
{
    "artists": [
        {
            "memberId": 1,
            "name": "혁기",
            "enName": "hucki"
        },
        {
            "memberId": 2,
            "name": "53X",
            "enName": "53X"
        },
        {
            "memberId": 3,
            "name": "덤프",
            "enName": "dump"
        },
        {
            "memberId": 4,
            "name": "이은성",
            "enName": "이은성"
        },
        {
            "memberId": 5,
            "name": "SKY",
            "enName": "SKY"
        },
        {
            "memberId": 6,
            "name": "블루키",
            "enName": "블루키"
        },
        {
            "memberId": 7,
            "name": "송민섭",
            "enName": "송민섭"
        }
    ]
}
```

## Reference
- reference1
