### PR TITLE
BPS-243/월별 매출-정산액 조회 API 구현 

### DIFF
--- a/src/main/java/com/github/bluekey/controller/album/AlbumController.java
+++ b/src/main/java/com/github/bluekey/controller/album/AlbumController.java
@@ -10,6 +10,7 @@ import com.github.bluekey.dto.response.album.AlbumTopResponseDto;
 import com.github.bluekey.dto.response.album.AlbumTrackAccountsResponseDto;
 import com.github.bluekey.dto.response.album.AlbumTrackListResponseDto;
 import com.github.bluekey.dto.response.artist.ArtistAlbumsListResponseDto;
+import com.github.bluekey.dto.response.common.MonthlyTrendResponseDto;
 import com.github.bluekey.jwt.PrincipalConvertUtil;
 import com.github.bluekey.service.album.AlbumService;
 import com.github.bluekey.service.dashboard.BarChartDashboardService;
@@ -157,7 +158,7 @@ public class AlbumController {
                     ))
     })
     @GetMapping("/{albumId}/dashboard")
-    public ResponseEntity<AlbumMonthlyAccontsReponseDto> getAlbumMonthlyAccounts(
+    public ResponseEntity<MonthlyTrendResponseDto> getAlbumMonthlyAccounts(
             @RequestParam("startDate") String startDate,
             @RequestParam("endDate") String endDate,
             @PathVariable("albumId") Long albumId

--- a/src/main/java/com/github/bluekey/controller/member/AdminController.java
+++ b/src/main/java/com/github/bluekey/controller/member/AdminController.java
@@ -7,9 +7,10 @@ import com.github.bluekey.dto.response.admin.AdminProfileResponseDto;
 import com.github.bluekey.dto.response.artist.ArtistAccountsResponseDto;
 import com.github.bluekey.dto.response.artist.ArtistsRevenueProportionResponseDto;
 import com.github.bluekey.dto.response.common.DashboardTotalInfoResponseDto;
-import com.github.bluekey.dto.response.common.MonthlyRevenueTrendResponseDto;
+import com.github.bluekey.dto.response.common.MonthlyTrendResponseDto;
 import com.github.bluekey.dto.response.track.TracksSettlementAmountResponseDto;
 import com.github.bluekey.jwt.PrincipalConvertUtil;
+import com.github.bluekey.service.dashboard.BarChartDashboardService;
 import com.github.bluekey.service.dashboard.SummaryDashBoardService;
 import com.github.bluekey.service.dashboard.TopTrackDashBoardService;
 import com.github.bluekey.service.member.MemberService;
@@ -41,6 +42,7 @@ public class AdminController {
 	private final MemberService memberService;
 	private final TopTrackDashBoardService topTrackDashBoardService;
 	private final SummaryDashBoardService summaryDashBoardService;
+	private final BarChartDashboardService barChartDashboardService;
 
 	@Operation(summary = "월별 Top n 아티스트 매출액과 비율", description = "월별 Top n 아티스트 매출액과 비율")
 	@ApiResponses(value = {
@@ -82,16 +84,17 @@ public class AdminController {
 		return ResponseEntity.ok(summaryDashBoardService.getAdminDashBoardSummaryInformation(monthly, PrincipalConvertUtil.getMemberId()));
 	}
 
+	// TODO: api 통일 필요
 	@Operation(summary = "월별 매출 추이", description = "월별 매출 추이")
 	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "정상 반환", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MonthlyRevenueTrendResponseDto.class))),
+			@ApiResponse(responseCode = "200", description = "정상 반환", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MonthlyTrendResponseDto.class))),
 	})
 	@GetMapping("/dashboard/trend")
-	public ResponseEntity<MonthlyRevenueTrendResponseDto> getMonthlyRevenueTrend(
+	public ResponseEntity<MonthlyTrendResponseDto> getMonthlyRevenueTrend(
 			@Parameter(description = "월별 추이의 시작일 (format: yyyy-MM)") @RequestParam("startDate") String startDate,
 			@Parameter(description = "월별 추이의 종료일 (format: yyyy-MM)") @RequestParam("endDate") String endDate
 	) {
-		return null;
+		return ResponseEntity.ok(barChartDashboardService.getBarChartDashboard(startDate, endDate, PrincipalConvertUtil.getMemberId()));
 	}
 
 	@Operation(summary = "관리자 프로필 수정", description = "관리자 프로필 수정")

--- a/src/main/java/com/github/bluekey/controller/member/ArtistController.java
+++ b/src/main/java/com/github/bluekey/controller/member/ArtistController.java
@@ -9,6 +9,7 @@ import com.github.bluekey.dto.request.artist.ArtistProfileRequestDto;
 import com.github.bluekey.dto.request.artist.ArtistRequestDto;
 import com.github.bluekey.dto.response.admin.AdminArtistProfileListReponseDto;
 import com.github.bluekey.dto.response.artist.*;
+import com.github.bluekey.dto.response.common.MonthlyTrendResponseDto;
 import com.github.bluekey.jwt.PrincipalConvertUtil;
 import com.github.bluekey.service.auth.AuthService;
 import com.github.bluekey.service.dashboard.BarChartDashboardService;
@@ -131,12 +132,13 @@ public class ArtistController {
         return ResponseEntity.ok(summaryDashBoardService.getArtistDashboardInformation(monthly, PrincipalConvertUtil.getMemberId()));
     }
 
+    // TODO: api 통일 필요
     @Operation(summary = "아티스트 대쉬보드 월별 정산액 LIST", description = "아티스트 대쉬보드 월별 정산액 LIST")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "아티스트 대쉬보드 월별 정산액 조회 완료", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ArtistMonthlyAccountsResponseDto.class))),
     })
     @GetMapping("/{memberId}/dashboard")
-    public ResponseEntity<ArtistMonthlyAccountsResponseDto> getArtistMonthlyAccounts(
+    public ResponseEntity<MonthlyTrendResponseDto> getArtistMonthlyAccounts(
             @RequestParam("startDate") String startDate,
             @RequestParam("endDate") String endDate,
             @PathVariable("memberId") Long memberId

--- a/src/main/java/com/github/bluekey/controller/member/ArtistController.java
+++ b/src/main/java/com/github/bluekey/controller/member/ArtistController.java
@@ -11,6 +11,7 @@ import com.github.bluekey.dto.response.admin.AdminArtistProfileListReponseDto;
 import com.github.bluekey.dto.response.artist.*;
 import com.github.bluekey.jwt.PrincipalConvertUtil;
 import com.github.bluekey.service.auth.AuthService;
+import com.github.bluekey.service.dashboard.BarChartDashboardService;
 import com.github.bluekey.service.dashboard.SummaryDashBoardService;
 import com.github.bluekey.service.dashboard.TopTrackDashBoardService;
 import com.github.bluekey.service.member.MemberService;
@@ -41,6 +42,7 @@ public class ArtistController {
     private final MemberService memberService;
     private final TopTrackDashBoardService topTrackDashBoardService;
     private final SummaryDashBoardService summaryDashBoardService;
+    private final BarChartDashboardService barChartDashboardService;
 
     @Operation(summary = "아티스트 정보 변경" , description = "아티스트 정보 변경")
     @ApiResponses(value = {
@@ -139,7 +141,7 @@ public class ArtistController {
             @RequestParam("endDate") String endDate,
             @PathVariable("memberId") Long memberId
     ) {
-        return null;
+        return ok(barChartDashboardService.getBarChartDashboard(startDate, endDate, memberId));
     }
 
     @Operation(summary = "Admin이 아티스트의 정보 변경" , description = "Admin이 아티스트의 정보 변경")

--- a/src/main/java/com/github/bluekey/dto/artist/ArtistMonthlyAccountsDto.java
+++ b/src/main/java/com/github/bluekey/dto/artist/ArtistMonthlyAccountsDto.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 @Schema(description = "아티스트의 월별 정산 정보")
 public class ArtistMonthlyAccountsDto {
@@ -14,15 +13,20 @@ public class ArtistMonthlyAccountsDto {
     private Integer month;
 
     @Schema(description = "정산액", example = "2142344")
-    private Long settlement;
+    private Double settlement;
 
     @Schema(description = "매출", example = "732143")
-    private Long revenue;
+    private double revenue;
+
+    @Schema(description = "회사 순이익", example = "732143")
+    private Double netIncome;
 
     @Builder
-    public ArtistMonthlyAccountsDto(final Integer month, final Long settlement, final Long revenue) {
+    public ArtistMonthlyAccountsDto(final Integer month, final Double settlement,
+            final double revenue, final Double netIncome) {
         this.month = month;
         this.settlement = settlement;
         this.revenue = revenue;
+        this.netIncome = netIncome;
     }
 }

--- a/src/main/java/com/github/bluekey/dto/common/MonthlyTrendDto.java
+++ b/src/main/java/com/github/bluekey/dto/common/MonthlyTrendDto.java
@@ -2,27 +2,29 @@ package com.github.bluekey.dto.common;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Schema(description = "월 매출 정보")
-public class MonthlyRevenueDto {
+@Schema(description = "월 매출 + 정산액 or 회사 순이익 정보")
+public class MonthlyTrendDto {
 	@Schema(description = "월", example = "1")
-	private Long month;
+	private Integer month;
 	@Schema(description = "매출", example = "1000000")
-	private Long revenue;
+	private double revenue;
 	@Schema(description = "순수익", example = "1000000")
-	private Long netIncome;
+	private Double netIncome;
+	@Schema(description = "정산액", example = "1000000")
+	private Double settlement;
 
 	@Builder
-	public MonthlyRevenueDto(final Long month, final Long revenue, final Long netIncome) {
+	public MonthlyTrendDto(final Integer month, final double revenue, final Double netIncome,
+			final Double settlement) {
 		this.month = month;
 		this.revenue = revenue;
 		this.netIncome = netIncome;
+		this.settlement = settlement;
 	}
 }

--- a/src/main/java/com/github/bluekey/dto/response/common/MonthlyTrendResponseDto.java
+++ b/src/main/java/com/github/bluekey/dto/response/common/MonthlyTrendResponseDto.java
@@ -1,10 +1,9 @@
 package com.github.bluekey.dto.response.common;
 
-import com.github.bluekey.dto.common.MonthlyRevenueDto;
+import com.github.bluekey.dto.common.MonthlyTrendDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,12 +11,12 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Schema(description = "월별 매출 추이")
-public class MonthlyRevenueTrendResponseDto {
+public class MonthlyTrendResponseDto {
 	@Schema(description = "월별 매출 정보 리스트")
-	private List<MonthlyRevenueDto> contents;
+	private List<MonthlyTrendDto> contents;
 
 	@Builder
-	public MonthlyRevenueTrendResponseDto(final List<MonthlyRevenueDto> contents) {
+	public MonthlyTrendResponseDto(final List<MonthlyTrendDto> contents) {
 		this.contents = contents;
 	}
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## What is this PR do?

- 월별 매출-정산액 조회 API 구현 

### TODO
api 통합 필요

## How it Works
```JSON
{
    "contents": [
        {
            "month": 7,
            "revenue": 9117.035543779026,
            "netIncome": 6381.924880645317,
            "settlement": null
        },
        {
            "month": 8,
            "revenue": 38677.03646834536,
            "netIncome": 27073.92552784175,
            "settlement": null
        }
    ]
}
```
어드민이 요청한 경우 (전체 트랙에 대한 매출)

```JSON
{
    "contents": [
        {
            "month": 8,
            "revenue": 1490.6307199999999,
            "netIncome": null,
            "settlement": 447.18921599999993
        }
    ]
}
```
아티스트가 요청한 경우 (본인이 참여한 트랙에 대한 정산액)
## Tests
- [ ] : Test1
- [ ] : Test2

## Reference
- reference1
