### PR TITLE
BPS-300/어드민이 비밀번호 재발급해주는 api 구현

### DIFF
--- a/src/main/java/com/github/bluekey/dto/response/auth/NewPasswordResponseDto.java
+++ b/src/main/java/com/github/bluekey/dto/response/auth/NewPasswordResponseDto.java
@@ -1,0 +1,19 @@
+package com.github.bluekey.dto.response.auth;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NewPasswordResponseDto {
+	@Schema(description = "새로운 비밀번호", example = "qwerty123")
+	private String newPassword;
+
+	@Builder
+	public NewPasswordResponseDto(final String newPassword) {
+		this.newPassword = newPassword;
+	}
+}

--- a/src/main/java/com/github/bluekey/dto/response/auth/NewPasswordResponseDto.java
+++ b/src/main/java/com/github/bluekey/dto/response/auth/NewPasswordResponseDto.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "아티스트의 임시 비밀번호 발급 응답")
 public class NewPasswordResponseDto {
 	@Schema(description = "새로운 비밀번호", example = "qwerty123")
 	private String newPassword;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## What is this PR do?

- member의 계정에 대해 비밀번호 재발급 해주는 API 구현

## How it Works
- [x] : 숫자 + 문자로 이루어진 10자리의 난수 비밀번호 생성
- [x] : 비밀번호 변경 후 반환 

## Tests
- [ ] : Test1
- [ ] : Test2

## Reference
- reference1
