### PR TITLE
BPS-328/Transaction table format 변경에 따른 대시보드 계산 로직 변경

### DIFF
--- a/src/main/java/com/github/bluekey/repository/track/TrackRepository.java
+++ b/src/main/java/com/github/bluekey/repository/track/TrackRepository.java
@@ -14,8 +14,7 @@ public interface TrackRepository extends JpaRepository<Track, Long> {
 
     Optional<Track> findTrackByNameIgnoreCaseAndAlbum(String name, Album album);
     Optional<Track> findTrackByEnNameIgnoreCaseAndAlbum(String enName, Album album);
-    Optional<Track> findTrackByNameIgnoreCaseOrEnNameIgnoreCaseAndAlbum(String name, String enName, Album album);
-    Optional<Track> findTrackByNameIgnoreCaseOrEnNameIgnoreCase(String name, String enName);
+    List<Track> findTrackByNameIgnoreCaseOrEnNameIgnoreCase(String name, String enName);
     Optional<Track> findTrackByNameIgnoreCase(String name);
     Optional<Track> findTrackByEnNameIgnoreCase(String enName);
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [x] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## What is this PR do?

- Transaction table에서 track field를 중심으로 대시보드 계산 로직이 변경되므로 dashboard Util class의 method 로직 수정
- Excel to DB migrate 로직에서 중복으로 amount가 계산이 되는 에러 수정

## How it Works
- [x] : DashboardUtilService의 로직을 Transaction table의 track field를 참조해서 연산이 이루어지도록 수정
- [x] : Excel to DB mirate method 수정

