### PR TITLE
fix: 아티스트 & 어드민 계정 목록 가져올 시 삭제된 유저 안 받아오도록 수정

### DIFF
--- a/src/main/java/com/github/bluekey/repository/member/MemberRepository.java
+++ b/src/main/java/com/github/bluekey/repository/member/MemberRepository.java
@@ -38,6 +38,9 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Page<Member> findMembersByRole(MemberRole role, PageRequest pageable);
 
+    Page<Member> findMembersByTypeAndIsRemovedFalse(MemberType type, PageRequest pageable);
+    Page<Member> findMembersByRoleAndIsRemovedFalse(MemberRole role, PageRequest pageable);
+
     List<Member> findMemberByRoleAndIsRemovedFalse(MemberRole role);
 
     List<Member> findMembersByRoleAndIsRemovedFalseAndNameContainingIgnoreCaseOrEnNameContainingIgnoreCase(MemberRole role, String name, String enName);

--- a/src/main/java/com/github/bluekey/service/member/MemberService.java
+++ b/src/main/java/com/github/bluekey/service/member/MemberService.java
@@ -88,7 +88,7 @@ public class MemberService {
 
     @Transactional(readOnly = true)
     public AdminAccountsResponseDto getAdminAccounts(PageRequest pageable) {
-        Page<Member> admins = memberRepository.findMembersByType(MemberType.ADMIN, pageable);
+        Page<Member> admins = memberRepository.findMembersByTypeAndIsRemovedFalse(MemberType.ADMIN, pageable);
         return AdminAccountsResponseDto.builder()
                 .totalItems(admins.getTotalElements())
                 .contents(admins.getContent().stream().map(AdminAccountDto::from).collect(Collectors.toList()))
@@ -98,7 +98,7 @@ public class MemberService {
     @Transactional(readOnly = true)
     public ArtistAccountsResponseDto getArtistAccounts(PageRequest pageable) {
 
-        Page<Member> artists = memberRepository.findMembersByRole(MemberRole.ARTIST, pageable);
+        Page<Member> artists = memberRepository.findMembersByRoleAndIsRemovedFalse(MemberRole.ARTIST, pageable);
         return ArtistAccountsResponseDto.builder()
                 .totalItems(artists.getTotalElements())
                 .contents(artists.getContent().stream().map(ArtistAccountDto::from).collect(Collectors.toList()))


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## What is this PR do?

- 삭제된 유저는 받아오지 않도록 수정

## How it Works
- [ ] : Task1
- [ ] : Task2

## Tests
- [ ] : Test1
- [ ] : Test2

## Reference
- reference1
