### PR TITLE
BPS-353/FEAT: request authority entity 생성

### DIFF
--- a/src/main/java/com/github/bluekey/entity/member/Member.java
+++ b/src/main/java/com/github/bluekey/entity/member/Member.java
@@ -1,8 +1,11 @@
 package com.github.bluekey.entity.member;
 
 import com.github.bluekey.entity.BaseTimeEntity;
+import com.github.bluekey.entity.notification.MemberRequestAuthority;
 import com.github.bluekey.exception.BusinessException;
 import com.github.bluekey.exception.ErrorCode;
+import java.util.ArrayList;
+import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -55,6 +58,13 @@ public class Member extends BaseTimeEntity {
 
 	@Column(name = "profile_image")
 	private String profileImage;
+
+	@OneToMany(
+			mappedBy = "member",
+			fetch = FetchType.LAZY,
+			cascade = CascadeType.ALL,
+			orphanRemoval = true)
+	private List<MemberRequestAuthority> memberRequestAuthorities = new ArrayList<>();
 
 	@Builder(builderClassName = "ByArtistBuilder", builderMethodName = "ByArtistBuilder")
 	public Member(String email, String loginId, String password, String name, String enName, Integer commissionRate, String profileImage) {

--- a/src/main/java/com/github/bluekey/entity/notification/MemberRequestAuthority.java
+++ b/src/main/java/com/github/bluekey/entity/notification/MemberRequestAuthority.java
@@ -1,0 +1,46 @@
+package com.github.bluekey.entity.notification;
+
+import com.github.bluekey.entity.member.Member;
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name="member_request_authority")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberRequestAuthority {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "member_request_authority_id")
+	private Long id;
+
+	@ManyToOne(optional = false, fetch = FetchType.LAZY)
+	@JoinColumn(name = "receiver_id")
+	private Member member;
+
+	@ManyToOne(optional = false, fetch = FetchType.LAZY)
+	@JoinColumn(name = "request_authority_id")
+	private RequestAuthority requestAuthority;
+
+	@Column(name = "created_at")
+	private LocalDateTime createdAt;
+
+	@Builder
+	public MemberRequestAuthority(Member member, RequestAuthority requestAuthority) {
+		this.member = member;
+		this.requestAuthority = requestAuthority;
+		this.createdAt = LocalDateTime.now();
+	}
+}

--- a/src/main/java/com/github/bluekey/entity/notification/RequestAuthority.java
+++ b/src/main/java/com/github/bluekey/entity/notification/RequestAuthority.java
@@ -1,10 +1,49 @@
 package com.github.bluekey.entity.notification;
 
+import com.github.bluekey.entity.BaseTimeEntity;
+import java.time.LocalDateTime;
+import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Getter
 @Entity
-public class RequestAuthority {
+@Table(name="request_authority")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RequestAuthority extends BaseTimeEntity {
+
 	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "request_authority_id")
 	private Long id;
+
+	@Column(name = "sender_id", nullable = false)
+	private Long senderId;
+
+	@Column(name = "confirm_at")
+	private LocalDateTime confirmAt;
+
+	@Column(name = "status", nullable = false)
+	@Enumerated(EnumType.STRING)
+	private RequestStatus status;
+
+	@Builder
+	public RequestAuthority(Long senderId) {
+		this.senderId = senderId;
+		this.status = RequestStatus.PENDING;
+	}
+
+	public void confirm(RequestStatus status) {
+		this.confirmAt = LocalDateTime.now();
+		this.status = status;
+	}
 }

--- a/src/main/java/com/github/bluekey/entity/notification/RequestStatus.java
+++ b/src/main/java/com/github/bluekey/entity/notification/RequestStatus.java
@@ -1,0 +1,5 @@
+package com.github.bluekey.entity.notification;
+
+public enum RequestStatus {
+	PENDING, ACCEPTED, REJECTED
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## What is this PR do?

- 슈퍼 어드민이 어드민 권한을 부여해주는 기능을 위한 Request Authority entity를 추가했습니다.
- Member와 Request Authority를 다대다로 mapping 해주기 위한 중간 테이블을 생성했습니다.

## How it Works
- [x] : RequestAuthority entity 생성
- [x] : MemberRequestAuthority 테이블 생성
- [x] : member에 관계 설정 

## Tests
- [ ] : Test1
- [ ] : Test2

## Reference
- reference1
